### PR TITLE
Add support for base64 encoded private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+github-app-commit-action

--- a/README.md
+++ b/README.md
@@ -2,24 +2,64 @@
 This GH action allow you to sign your commits with a Github App
 
 ## Inputs
-| Variable | Description | Type |
-| -------- | ----------- | ---- |
-| `github-app-id` | **Required**. The Github App ID. | `string` |
-| `github-app-private-key-file` | The Github App private key filename. | `string` |
-| `repository` | **Required**. GitHub repository in the format owner/repo | `string` |
-| `branch` | Target branch to commit to (default "main")| `string` |
-| `head` | head branch to commit from. Default is the same as branch | `string` |
-| `message` | Commit message (default "chore: autopublish ${date}") | `string` |
-| `add-new-files` | Add new files to the commit. (default true) | `bool` |
-| `coauthors` | Coauthors in the format 'Name1 <email1>, Name2 <email2>' | `string` |
+| Variable | Description | Type | Required | Default |
+| -------- | ----------- | ---- | -------- | ------- |
+| `github-app-id` | The Github App ID. | `string` | Yes | - |
+| `github-app-private-key` | The Github App private key in PEM format. Can be plain PEM or base64-encoded PEM. | `string` | No* | - |
+| `github-app-private-key-file` | Path to the Github App private key PEM file. | `string` | No* | - |
+| `repository` | GitHub repository in the format owner/repo | `string` | Yes | - |
+| `branch` | Target branch to commit to | `string` | Yes | `main` |
+| `head` | Head branch to commit from | `string` | No | Same as `branch` |
+| `message` | Commit message | `string` | No | `chore: autopublish ${date}` |
+| `force-push` | Force push to the branch | `bool` | No | `false` |
+| `tags` | Comma-separated tags to create for the commit | `string` | No | - |
+| `add-new-files` | Add new files to the commit | `bool` | No | `true` |
+| `coauthors` | Coauthors in the format 'Name1 <email1>, Name2 <email2>' | `string` | No | - |
+
+\* Either `github-app-private-key` or `github-app-private-key-file` must be provided.
+
+### Private Key Format
+
+The `github-app-private-key` input accepts the private key in two formats:
+- **Plain PEM**: Standard PEM format (multiline string beginning with `-----BEGIN RSA PRIVATE KEY-----`)
+- **Base64-encoded PEM**: The entire PEM content encoded as base64 (useful in CI/CD environments where multiline secrets are difficult to handle)
+
+The action will automatically detect and decode base64-encoded keys.
 
 ## Example usage
+
+### Using private key from secrets
 ```yaml
 uses: arcezd/github-app-commit-action@v1
 with:
+  github-app-id: ${{ secrets.GH_APP_ID }}
+  github-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
   repository: ${{ github.repository }}
   branch: "new-branch"
   head: "main"
+  message: "feat: automated commit"
+```
+
+### Using private key file
+```yaml
+uses: arcezd/github-app-commit-action@v1
+with:
+  github-app-id: ${{ secrets.GH_APP_ID }}
+  github-app-private-key-file: "./path/to/private-key.pem"
+  repository: ${{ github.repository }}
+  branch: "new-branch"
+```
+
+### Creating tags
+```yaml
+uses: arcezd/github-app-commit-action@v1
+with:
+  github-app-id: ${{ secrets.GH_APP_ID }}
+  github-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+  repository: ${{ github.repository }}
+  branch: "main"
+  tags: "v1.0.0, production"
+  message: "release: version 1.0.0"
 ```
 
 ## TODO

--- a/helper/errors_test.go
+++ b/helper/errors_test.go
@@ -1,0 +1,51 @@
+package github_helper
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGitHubAPIError_Error(t *testing.T) {
+	err := &GitHubAPIError{StatusCode: 404, Body: "not found"}
+	expected := "error calling github api, status code: 404, response: not found"
+
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestIsNotFound_404(t *testing.T) {
+	err := &GitHubAPIError{StatusCode: 404, Body: "not found"}
+	if !IsNotFound(err) {
+		t.Error("expected IsNotFound to return true for 404")
+	}
+}
+
+func TestIsNotFound_Non404(t *testing.T) {
+	err := &GitHubAPIError{StatusCode: 403, Body: "forbidden"}
+	if IsNotFound(err) {
+		t.Error("expected IsNotFound to return false for 403")
+	}
+}
+
+func TestIsNotFound_NonAPIError(t *testing.T) {
+	err := fmt.Errorf("some other error")
+	if IsNotFound(err) {
+		t.Error("expected IsNotFound to return false for non-API error")
+	}
+}
+
+func TestIsNotFound_WrappedError(t *testing.T) {
+	apiErr := &GitHubAPIError{StatusCode: 404, Body: "not found"}
+	wrapped := fmt.Errorf("wrapped: %w", apiErr)
+
+	if !IsNotFound(wrapped) {
+		t.Error("expected IsNotFound to return true for wrapped 404 error")
+	}
+}
+
+func TestIsNotFound_Nil(t *testing.T) {
+	if IsNotFound(nil) {
+		t.Error("expected IsNotFound to return false for nil")
+	}
+}

--- a/helper/github.go
+++ b/helper/github.go
@@ -18,25 +18,32 @@ var (
 	initJwt, initToken sync.Once
 	ghAppSignedToken   string
 	ghAppToken         *GitHubAppToken = nil
+	initJwtErr         error
 )
 
-func initAppToken(appId string, privatePem []byte) {
+func initAppToken(appId string, privatePem []byte) error {
 	initJwt.Do(func() {
 		token, err := GenerateToken(appId, privatePem)
 		if err != nil {
-			panic(err)
+			initJwtErr = err
+			return
 		}
 		ghAppSignedToken = token
 	})
+
+	return initJwtErr
 }
 
-func SetGithubAppToken(token *GitHubAppToken) {
+func SetGithubAppToken(token *GitHubAppToken) error {
+	if token == nil {
+		return fmt.Errorf("GitHub App Token not provided")
+	}
+
 	initToken.Do(func() {
-		if token == nil {
-			panic("GitHub App Token not provided")
-		}
 		ghAppToken = token
 	})
+
+	return nil
 }
 
 // generate jwt token
@@ -81,7 +88,7 @@ func GenerateInstallationAccessToken(token string, installationId int) (string, 
 
 func GetReference(ref string) (GithubRefResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubRefResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	var respObj GithubRefResponse
 	response, err := CallGithubAPI(ghAppToken.Token, "GET", fmt.Sprintf("/repos/%s/%s/git/%s", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo, ref), nil)
@@ -99,7 +106,7 @@ func GetReference(ref string) (GithubRefResponse, error) {
 
 func CreateTree(tree GithubTreeRequest) (GithubTreeResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubTreeResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	githubTreeResponse := GithubTreeResponse{}
 	response, err := CallGithubAPI(ghAppToken.Token, "POST", fmt.Sprintf("/repos/%s/%s/git/trees", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo), tree)
@@ -117,7 +124,7 @@ func CreateTree(tree GithubTreeRequest) (GithubTreeResponse, error) {
 
 func CreateCommit(commit GithubCommitRequest) (GithubCommitResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubCommitResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	var respObj GithubCommitResponse
 	response, err := CallGithubAPI(ghAppToken.Token, "POST", fmt.Sprintf("/repos/%s/%s/git/commits", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo), commit)
@@ -135,7 +142,7 @@ func CreateCommit(commit GithubCommitRequest) (GithubCommitResponse, error) {
 
 func CreateReference(request GithubRefRequest) (GithubRefResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubRefResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	var respObj GithubRefResponse
 	response, err := CallGithubAPI(ghAppToken.Token, "POST", fmt.Sprintf("/repos/%s/%s/git/refs", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo), request)
@@ -153,7 +160,7 @@ func CreateReference(request GithubRefRequest) (GithubRefResponse, error) {
 
 func UpdateReference(request GithubRefRequest, ref string, createBranch bool) (GithubRefResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubRefResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	if createBranch {
 		// Remove "heads/" prefix if present, then add "refs/heads/"
@@ -187,7 +194,7 @@ func UpdateReference(request GithubRefRequest, ref string, createBranch bool) (G
 
 func CreateBlob(blob GithubBlobRequest) (GithubBlobResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubBlobResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	var respObj GithubBlobResponse
 	response, err := CallGithubAPI(ghAppToken.Token, "POST", fmt.Sprintf("/repos/%s/%s/git/blobs", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo), blob)
@@ -205,7 +212,7 @@ func CreateBlob(blob GithubBlobRequest) (GithubBlobResponse, error) {
 
 func CreateTag(tag GithubTagRequest) (GithubTagResponse, error) {
 	if ghAppToken == nil {
-		panic("GitHub App Token not initialized")
+		return GithubTagResponse{}, fmt.Errorf("GitHub App Token not initialized")
 	}
 	var respObj GithubTagResponse
 	response, err := CallGithubAPI(ghAppToken.Token, "POST", fmt.Sprintf("/repos/%s/%s/git/tags", ghAppToken.Repo.Owner, ghAppToken.Repo.Repo), tag)

--- a/helper/github.go
+++ b/helper/github.go
@@ -279,7 +279,7 @@ func CallGithubAPI(token string, method string, path string, data interface{}) (
 
 	// check http status code
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("error calling github api, status code: %d, response: %s", resp.StatusCode, string(b))
+		return "", &GitHubAPIError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	return string(b), nil

--- a/helper/github_test.go
+++ b/helper/github_test.go
@@ -1,0 +1,626 @@
+//nolint:goconst
+package github_helper
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// CallGithubAPI
+// ---------------------------------------------------------------------------
+
+func TestCallGithubAPI_GetSuccess(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+
+		if r.Header.Get("Accept") != "application/vnd.github+json" {
+			t.Errorf("unexpected accept header: %s", r.Header.Get("Accept"))
+		}
+
+		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Errorf("unexpected api version header: %s", r.Header.Get("X-GitHub-Api-Version"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"key":"value"}`))
+	}))
+
+	resp, err := CallGithubAPI("test-token", "GET", "/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp != `{"key":"value"}` {
+		t.Errorf("unexpected response: %s", resp)
+	}
+}
+
+func TestCallGithubAPI_PostWithBody(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var data map[string]string
+		_ = json.Unmarshal(body, &data)
+
+		if data["name"] != "test" {
+			t.Errorf("unexpected body: %s", string(body))
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"abc123"}`))
+	}))
+
+	resp, err := CallGithubAPI("test-token", "POST", "/test", map[string]string{"name": "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(resp, "abc123") {
+		t.Errorf("unexpected response: %s", resp)
+	}
+}
+
+func TestCallGithubAPI_404Error(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+
+	_, err := CallGithubAPI("test-token", "GET", "/not-found", nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+
+	if !IsNotFound(err) {
+		t.Errorf("expected 404 error, got: %v", err)
+	}
+}
+
+func TestCallGithubAPI_500Error(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+	}))
+
+	_, err := CallGithubAPI("test-token", "GET", "/error", nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+
+	apiErr, ok := err.(*GitHubAPIError)
+	if !ok {
+		t.Fatalf("expected GitHubAPIError, got %T", err)
+	}
+
+	if apiErr.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", apiErr.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenerateToken
+// ---------------------------------------------------------------------------
+
+func TestGenerateToken_ValidKey(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	token, err := GenerateToken("12345", pemBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token == "" {
+		t.Error("expected non-empty token")
+	}
+
+	// JWT has 3 parts
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Errorf("expected 3 JWT parts, got %d", len(parts))
+	}
+}
+
+func TestGenerateToken_InvalidPEM(t *testing.T) {
+	_, err := GenerateToken("12345", []byte("not-a-valid-pem"))
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenerateInstallationAccessToken
+// ---------------------------------------------------------------------------
+
+func TestGenerateInstallationAccessToken_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/app/installations/42/access_tokens") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"ghs_test123","expires_at":"2024-01-01T00:00:00Z"}`))
+	}))
+
+	token, err := GenerateInstallationAccessToken("jwt-token", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token != "ghs_test123" {
+		t.Errorf("expected ghs_test123, got %s", token)
+	}
+}
+
+func TestGenerateInstallationAccessToken_APIError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+
+	_, err := GenerateInstallationAccessToken("bad-token", 42)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGenerateInstallationAccessToken_InvalidJSON(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+
+	_, err := GenerateInstallationAccessToken("jwt-token", 42)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetReference
+// ---------------------------------------------------------------------------
+
+func TestGetReference_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, GithubRefResponse{
+			Ref:    "refs/heads/main",
+			Object: RefObject{Sha: "abc123", Type: "commit"},
+		})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	ref, err := GetReference("refs/heads/main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ref.Object.Sha != "abc123" {
+		t.Errorf("expected sha abc123, got %s", ref.Object.Sha)
+	}
+}
+
+func TestGetReference_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := GetReference("refs/heads/main")
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+func TestGetReference_APIError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	_, err := GetReference("refs/heads/nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateTree
+// ---------------------------------------------------------------------------
+
+func TestCreateTree_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := CreateTree(GithubTreeRequest{BaseTree: "base", Tree: []TreeItem{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Sha != "tree-sha" {
+		t.Errorf("expected tree-sha, got %s", resp.Sha)
+	}
+}
+
+func TestCreateTree_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := CreateTree(GithubTreeRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateCommit
+// ---------------------------------------------------------------------------
+
+func TestCreateCommit_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := CreateCommit(GithubCommitRequest{Message: "test", Tree: "tree-sha", Parents: []string{"parent"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Sha != "commit-sha" {
+		t.Errorf("expected commit-sha, got %s", resp.Sha)
+	}
+}
+
+func TestCreateCommit_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := CreateCommit(GithubCommitRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateReference
+// ---------------------------------------------------------------------------
+
+func TestCreateReference_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubRefResponse{
+			Ref:    "refs/heads/new-branch",
+			Object: RefObject{Sha: "ref-sha"},
+		})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := CreateReference(GithubRefRequest{Ref: "refs/heads/new-branch", Sha: "ref-sha"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Object.Sha != "ref-sha" {
+		t.Errorf("expected ref-sha, got %s", resp.Object.Sha)
+	}
+}
+
+func TestCreateReference_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := CreateReference(GithubRefRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateReference
+// ---------------------------------------------------------------------------
+
+func TestUpdateReference_PatchSuccess(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+
+		jsonResponse(w, http.StatusOK, GithubRefResponse{
+			Ref:    "refs/heads/main",
+			Object: RefObject{Sha: "updated-sha"},
+		})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := UpdateReference(GithubRefRequest{Sha: "updated-sha"}, "heads/main", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Object.Sha != "updated-sha" {
+		t.Errorf("expected updated-sha, got %s", resp.Object.Sha)
+	}
+}
+
+func TestUpdateReference_CreateBranch(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST for create branch, got %s", r.Method)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req GithubRefRequest
+		_ = json.Unmarshal(body, &req)
+
+		if !strings.HasPrefix(req.Ref, "refs/heads/") {
+			t.Errorf("expected refs/heads/ prefix, got %s", req.Ref)
+		}
+
+		jsonResponse(w, http.StatusCreated, GithubRefResponse{
+			Ref:    req.Ref,
+			Object: RefObject{Sha: "new-sha"},
+		})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := UpdateReference(GithubRefRequest{Sha: "new-sha"}, "heads/new-branch", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Object.Sha != "new-sha" {
+		t.Errorf("expected new-sha, got %s", resp.Object.Sha)
+	}
+}
+
+func TestUpdateReference_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := UpdateReference(GithubRefRequest{}, "heads/main", false)
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateBlob
+// ---------------------------------------------------------------------------
+
+func TestCreateBlob_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha", Url: "http://test"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := CreateBlob(GithubBlobRequest{Content: "dGVzdA==", Encoding: "base64"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Sha != "blob-sha" {
+		t.Errorf("expected blob-sha, got %s", resp.Sha)
+	}
+}
+
+func TestCreateBlob_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := CreateBlob(GithubBlobRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateTag
+// ---------------------------------------------------------------------------
+
+func TestCreateTag_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubTagResponse{Sha: "tag-sha", Tag: "v1.0.0"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	resp, err := CreateTag(GithubTagRequest{Tag: "v1.0.0", Message: "release", Object: "commit-sha", Type: "commit"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Sha != "tag-sha" {
+		t.Errorf("expected tag-sha, got %s", resp.Sha)
+	}
+}
+
+func TestCreateTag_NilToken(t *testing.T) {
+	resetGlobals()
+
+	_, err := CreateTag(GithubTagRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAppInstallationDetails
+// ---------------------------------------------------------------------------
+
+func TestGetAppInstallationDetails_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/repos/owner/repo/installation") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		jsonResponse(w, http.StatusOK, GithubAppInstallationResponse{Id: 42, AppId: 12345})
+	}))
+
+	resp, err := GetAppInstallationDetails("jwt-token", GitHubRepo{Owner: "owner", Repo: "repo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Id != 42 {
+		t.Errorf("expected installation id 42, got %d", resp.Id)
+	}
+}
+
+func TestGetAppInstallationDetails_APIError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+
+	_, err := GetAppInstallationDetails("jwt-token", GitHubRepo{Owner: "owner", Repo: "repo"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// initAppToken
+// ---------------------------------------------------------------------------
+
+func TestInitAppToken_Success(t *testing.T) {
+	resetGlobals()
+
+	pemBytes := generateTestRSAKey(t)
+
+	err := initAppToken("12345", pemBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ghAppSignedToken == "" {
+		t.Error("expected non-empty signed token")
+	}
+}
+
+func TestInitAppToken_InvalidPEM(t *testing.T) {
+	resetGlobals()
+
+	err := initAppToken("12345", []byte("invalid"))
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestInitAppToken_OnlyRunsOnce(t *testing.T) {
+	resetGlobals()
+
+	pemBytes := generateTestRSAKey(t)
+
+	err := initAppToken("12345", pemBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	firstToken := ghAppSignedToken
+
+	// Second call should be no-op (sync.Once)
+	err = initAppToken("99999", pemBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ghAppSignedToken != firstToken {
+		t.Error("expected token to remain unchanged after second call")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetGithubAppToken
+// ---------------------------------------------------------------------------
+
+func TestSetGithubAppToken_Success(t *testing.T) {
+	resetGlobals()
+
+	token := &GitHubAppToken{Token: "test", Repo: GitHubRepo{Owner: "o", Repo: "r"}}
+
+	err := SetGithubAppToken(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ghAppToken == nil {
+		t.Fatal("expected token to be set")
+	}
+
+	if ghAppToken.Token != "test" {
+		t.Errorf("expected token 'test', got '%s'", ghAppToken.Token)
+	}
+}
+
+func TestSetGithubAppToken_Nil(t *testing.T) {
+	resetGlobals()
+
+	err := SetGithubAppToken(nil)
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+func TestSetGithubAppToken_OnlyRunsOnce(t *testing.T) {
+	resetGlobals()
+
+	token1 := &GitHubAppToken{Token: "first", Repo: GitHubRepo{Owner: "o", Repo: "r"}}
+	token2 := &GitHubAppToken{Token: "second", Repo: GitHubRepo{Owner: "o", Repo: "r"}}
+
+	_ = SetGithubAppToken(token1)
+	_ = SetGithubAppToken(token2)
+
+	if ghAppToken.Token != "first" {
+		t.Errorf("expected 'first' (sync.Once), got '%s'", ghAppToken.Token)
+	}
+}

--- a/helper/github_types.go
+++ b/helper/github_types.go
@@ -1,6 +1,28 @@
 package github_helper
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// GitHubAPIError represents a non-2xx response from the GitHub API.
+type GitHubAPIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *GitHubAPIError) Error() string {
+	return fmt.Sprintf("error calling github api, status code: %d, response: %s", e.StatusCode, e.Body)
+}
+
+// IsNotFound returns true if the error is a GitHub API 404 response.
+func IsNotFound(err error) bool {
+	var apiErr *GitHubAPIError
+
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
 
 type GitHubRepo struct {
 	Owner string `json:"owner"`

--- a/helper/main.go
+++ b/helper/main.go
@@ -111,49 +111,52 @@ func UploadFilesToGitHubBlob(files []string) ([]GitFile, error) {
 	return gitFiles, nil
 }
 
-func SignJWTAppToken(appId string, privatePem []byte) {
-	initAppToken(appId, privatePem)
+func SignJWTAppToken(appId string, privatePem []byte) error {
+	return initAppToken(appId, privatePem)
 }
 
-func SignJWTAppTokenWithFilename(appId string, pemFilename string) {
+func SignJWTAppTokenWithFilename(appId string, pemFilename string) error {
 	if pemFilename == "" {
-		panic("PEM file not provided")
+		return fmt.Errorf("PEM file not provided")
 	}
 
 	// read the private key from a file
 	privatePem, err := os.ReadFile(pemFilename)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error reading PEM file: %w", err)
 	}
-	SignJWTAppToken(appId, privatePem)
+
+	return SignJWTAppToken(appId, privatePem)
 }
 
-func GenerateInstallationAppToken(repo GitHubRepo) GitHubAppToken {
+func GenerateInstallationAppToken(repo GitHubRepo) (GitHubAppToken, error) {
 	// get app installation details
 	app, err := GetAppInstallationDetails(ghAppSignedToken, repo)
 	if err != nil {
-		panic(err)
+		return GitHubAppToken{}, fmt.Errorf("error getting app installation details: %w", err)
 	}
 
 	// generate installation app token
 	installationToken, err := GenerateInstallationAccessToken(ghAppSignedToken, app.Id)
 	if err != nil {
-		panic(err)
+		return GitHubAppToken{}, fmt.Errorf("error generating installation access token: %w", err)
 	}
+
 	return GitHubAppToken{
 		Repo:  repo,
 		Token: installationToken,
-	}
+	}, nil
 }
 
-func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
+func CommitAndPush(repo GitHubRepo, commit GitCommit) (string, error) {
 	// get head reference
 	if commit.HeadBranch == nil {
 		commit.HeadBranch = &commit.Branch
 	}
+
 	githubRefResponse, err := GetReference(fmt.Sprintf("refs/heads/%s", *commit.HeadBranch))
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error getting head reference: %w", err)
 	}
 
 	// get files to commit
@@ -163,14 +166,15 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 	} else {
 		files, err = GetModifiedFiles()
 	}
+
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error getting files to commit: %w", err)
 	}
 
 	// upload files to github blobs
 	gitFiles, err := UploadFilesToGitHubBlob(files)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error uploading files to GitHub: %w", err)
 	}
 
 	// create git tree
@@ -183,18 +187,22 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 			Sha:  file.Sha,
 		})
 	}
+
 	treeReq := GithubTreeRequest{
 		BaseTree: githubRefResponse.Object.Sha,
 		Tree:     treeFiles,
 	}
+
 	b, err := json.Marshal(treeReq)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error marshaling tree request: %w", err)
 	}
+
 	fmt.Println(string(b))
+
 	treeResp, err := CreateTree(treeReq)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error creating tree: %w", err)
 	}
 
 	// add coauthors and on-behalf-of to commit message
@@ -206,6 +214,7 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 				commitMessage = fmt.Sprintf("%sCo-authored-by: %s <%s>\n", commitMessage, coauthor.Name, coauthor.Email)
 			}
 		}
+
 		if commit.OnBehalfOf != nil {
 			commitMessage = fmt.Sprintf("%son-behalf-of: @%s <%s>", commitMessage, commit.OnBehalfOf.Slug, commit.OnBehalfOf.Email)
 		}
@@ -219,9 +228,10 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 			githubRefResponse.Object.Sha,
 		},
 	}
+
 	commitResp, err := CreateCommit(commitReq)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error creating commit: %w", err)
 	}
 
 	// update git reference
@@ -232,7 +242,7 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 	if commit.Options.Force {
 		refReq.Force = true
 	}
-	
+
 	// try to update the branch first (most common case)
 	refResp, err := UpdateReference(refReq, fmt.Sprintf("heads/%s", commit.Branch), false)
 	if err != nil {
@@ -242,8 +252,9 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 	} else {
 		fmt.Printf("Target branch '%s' updated.\n", commit.Branch)
 	}
+
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("error updating reference: %w", err)
 	}
 
 	message := fmt.Sprintf("Commit '%s' pushed to branch '%s' with SHA '%s'\n", commit.Message, commit.Branch, refResp.Object.Sha)
@@ -251,10 +262,11 @@ func CommitAndPush(repo GitHubRepo, commit GitCommit) string {
 	AppendToGHActionsSummary(message)
 
 	SendToGHActionsOutput("sha", refResp.Object.Sha)
-	return refResp.Object.Sha
+
+	return refResp.Object.Sha, nil
 }
 
-func CreateTagAndPush(tag GitTag) {
+func CreateTagAndPush(tag GitTag) error {
 	// create tag
 	tagResp, err := CreateTag(GithubTagRequest{
 		Tag:     tag.TagName,
@@ -264,7 +276,7 @@ func CreateTagAndPush(tag GitTag) {
 		Tagger:  nil,
 	})
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error creating tag '%s': %w", tag.TagName, err)
 	}
 
 	// check if tag already exists
@@ -272,22 +284,33 @@ func CreateTagAndPush(tag GitTag) {
 	if err == nil {
 		// tag already exists
 		fmt.Printf("Tag '%s' already exists. Updating\n", tag.TagName)
-		UpdateReference(GithubRefRequest{
+
+		_, err = UpdateReference(GithubRefRequest{
 			Sha:   tagResp.Sha,
 			Force: true,
 		}, fmt.Sprintf("tags/%s", tag.TagName), false)
+		if err != nil {
+			return fmt.Errorf("error updating tag '%s': %w", tag.TagName, err)
+		}
+
 		message := fmt.Sprintf("Tag '%s' updated with Sha %s\n", tag.TagName, tagResp.Sha)
 		fmt.Print(message)
 		AppendToGHActionsSummary(message)
 	} else {
 		// create tag reference
-		CreateReference(GithubRefRequest{
+		_, err = CreateReference(GithubRefRequest{
 			Ref:   fmt.Sprintf("refs/tags/%s", tag.TagName),
 			Sha:   tagResp.Sha,
 			Force: true,
 		})
+		if err != nil {
+			return fmt.Errorf("error creating tag reference '%s': %w", tag.TagName, err)
+		}
+
 		message := fmt.Sprintf("Tag '%s' with Sha %s created\n", tag.TagName, tagResp.Sha)
 		fmt.Print(message)
 		AppendToGHActionsSummary(message)
 	}
+
+	return nil
 }

--- a/helper/main.go
+++ b/helper/main.go
@@ -48,7 +48,7 @@ type GitTag struct {
 func UploadFileToGitHubBlob(filename string) (GithubBlobResponse, error) {
 	resp := GithubBlobResponse{}
 	// check if file exists
-	_, err := os.Stat(filename)
+	_, err := os.Stat(filename) //nolint:gosec // filename comes from git diff output, not user input
 	if err != nil {
 		if os.IsNotExist(err) {
 			// file does not exist
@@ -61,10 +61,11 @@ func UploadFileToGitHubBlob(filename string) (GithubBlobResponse, error) {
 		}
 	} else {
 		// read file content
-		content, err := os.ReadFile(filename)
+		content, err := os.ReadFile(filename) //nolint:gosec // filename comes from git diff output
 		if err != nil {
 			return resp, err
 		}
+
 		base64Content := base64.StdEncoding.EncodeToString(content)
 		req := GithubBlobRequest{
 			Content:  base64Content,
@@ -75,6 +76,7 @@ func UploadFileToGitHubBlob(filename string) (GithubBlobResponse, error) {
 		if err != nil {
 			return resp, err
 		}
+
 		return resp, nil
 	}
 }
@@ -82,6 +84,7 @@ func UploadFileToGitHubBlob(filename string) (GithubBlobResponse, error) {
 func UploadFilesToGitHubBlob(files []string) ([]GitFile, error) {
 	//ch := make(chan string, len(files))
 	gitFiles := []GitFile{}
+
 	for _, filename := range files {
 		//go func() {
 		//	res, _ := requester.Get(insrequester.RequestEntity{Endpoint: url})
@@ -108,6 +111,7 @@ func UploadFilesToGitHubBlob(files []string) ([]GitFile, error) {
 			})
 		}
 	}
+
 	return gitFiles, nil
 }
 
@@ -121,7 +125,7 @@ func SignJWTAppTokenWithFilename(appId string, pemFilename string) error {
 	}
 
 	// read the private key from a file
-	privatePem, err := os.ReadFile(pemFilename)
+	privatePem, err := os.ReadFile(pemFilename) //nolint:gosec // pemFilename is from CLI flag, trusted input
 	if err != nil {
 		return fmt.Errorf("error reading PEM file: %w", err)
 	}

--- a/helper/main_test.go
+++ b/helper/main_test.go
@@ -1,0 +1,822 @@
+//nolint:goconst
+package github_helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// UploadFileToGitHubBlob
+// ---------------------------------------------------------------------------
+
+func TestUploadFileToGitHubBlob_Success(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha", Url: "http://test"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	// Create a temp file
+	tmpFile, err := os.CreateTemp("", "test-blob-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("test content")
+	tmpFile.Close()
+
+	resp, err := UploadFileToGitHubBlob(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Sha != "blob-sha" {
+		t.Errorf("expected blob-sha, got %s", resp.Sha)
+	}
+}
+
+func TestUploadFileToGitHubBlob_NonExistentFile(t *testing.T) {
+	resetGlobals()
+
+	_, err := UploadFileToGitHubBlob("/nonexistent/path/file.txt")
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+}
+
+func TestUploadFileToGitHubBlob_APIError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"error"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	tmpFile, err := os.CreateTemp("", "test-blob-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("test content")
+	tmpFile.Close()
+
+	_, err = UploadFileToGitHubBlob(tmpFile.Name())
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UploadFilesToGitHubBlob
+// ---------------------------------------------------------------------------
+
+func TestUploadFilesToGitHubBlob_MixedFiles(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha", Url: "http://test"})
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	// Create a real file
+	tmpFile, err := os.CreateTemp("", "test-upload-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("content")
+	tmpFile.Close()
+
+	files := []string{tmpFile.Name(), "/nonexistent/deleted-file.go"}
+
+	gitFiles, err := UploadFilesToGitHubBlob(files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(gitFiles) != 2 {
+		t.Fatalf("expected 2 git files, got %d", len(gitFiles))
+	}
+
+	if gitFiles[0].WasDeleted {
+		t.Error("expected first file to not be deleted")
+	}
+
+	if !gitFiles[1].WasDeleted {
+		t.Error("expected second file to be marked as deleted")
+	}
+}
+
+func TestUploadFilesToGitHubBlob_EmptyList(t *testing.T) {
+	resetGlobals()
+
+	gitFiles, err := UploadFilesToGitHubBlob([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(gitFiles) != 0 {
+		t.Errorf("expected 0 files, got %d", len(gitFiles))
+	}
+}
+
+func TestUploadFilesToGitHubBlob_APIErrorOnExistingFile(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"error"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	tmpFile, err := os.CreateTemp("", "test-upload-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("content")
+	tmpFile.Close()
+
+	_, err = UploadFilesToGitHubBlob([]string{tmpFile.Name()})
+	if err == nil {
+		t.Fatal("expected error for API error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SignJWTAppToken
+// ---------------------------------------------------------------------------
+
+func TestSignJWTAppToken_Success(t *testing.T) {
+	resetGlobals()
+
+	pemBytes := generateTestRSAKey(t)
+
+	err := SignJWTAppToken("12345", pemBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSignJWTAppToken_InvalidPEM(t *testing.T) {
+	resetGlobals()
+
+	err := SignJWTAppToken("12345", []byte("invalid"))
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SignJWTAppTokenWithFilename
+// ---------------------------------------------------------------------------
+
+func TestSignJWTAppTokenWithFilename_Success(t *testing.T) {
+	resetGlobals()
+
+	pemBytes := generateTestRSAKey(t)
+
+	tmpFile, err := os.CreateTemp("", "test-pem-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.Write(pemBytes)
+	tmpFile.Close()
+
+	err = SignJWTAppTokenWithFilename("12345", tmpFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSignJWTAppTokenWithFilename_EmptyFilename(t *testing.T) {
+	resetGlobals()
+
+	err := SignJWTAppTokenWithFilename("12345", "")
+	if err == nil {
+		t.Fatal("expected error for empty filename")
+	}
+}
+
+func TestSignJWTAppTokenWithFilename_MissingFile(t *testing.T) {
+	resetGlobals()
+
+	err := SignJWTAppTokenWithFilename("12345", "/nonexistent/file.pem")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenerateInstallationAppToken
+// ---------------------------------------------------------------------------
+
+func TestGenerateInstallationAppToken_Success(t *testing.T) {
+	resetGlobals()
+
+	pemBytes := generateTestRSAKey(t)
+	_ = initAppToken("12345", pemBytes)
+
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// access_tokens path also contains "installation", so check it first
+		if strings.Contains(r.URL.Path, "/access_tokens") {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"ghs_install_token","expires_at":"2024-01-01T00:00:00Z"}`))
+
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/installation") {
+			jsonResponse(w, http.StatusOK, GithubAppInstallationResponse{Id: 42})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+
+	token, err := GenerateInstallationAppToken(GitHubRepo{Owner: "owner", Repo: "repo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token.Token != "ghs_install_token" {
+		t.Errorf("expected ghs_install_token, got %s", token.Token)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CommitAndPush
+// ---------------------------------------------------------------------------
+
+func TestCommitAndPush_HappyPath(t *testing.T) {
+	resetGlobals()
+
+	// Mock exec for git commands
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if command == "git" && len(args) > 0 {
+			if args[0] == "add" {
+				return []byte(""), nil
+			}
+
+			if args[0] == "diff" {
+				return []byte("file1.go\n"), nil
+			}
+		}
+
+		return []byte(""), nil
+	})
+
+	// Create a temp file that UploadFileToGitHubBlob can find
+	tmpFile, err := os.CreateTemp("", "file1.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("package main")
+	tmpFile.Close()
+
+	// Mock git diff to return the temp file name
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if command == "git" && len(args) > 0 {
+			if args[0] == "add" {
+				return []byte(""), nil
+			}
+
+			if args[0] == "diff" {
+				return []byte(tmpFile.Name() + "\n"), nil
+			}
+		}
+
+		return []byte(""), nil
+	})
+
+	// Set up summary/output env
+	summaryFile, _ := os.CreateTemp("", "gh-summary-*")
+	defer os.Remove(summaryFile.Name())
+
+	summaryFile.Close()
+
+	outputFile, _ := os.CreateTemp("", "gh-output-*")
+	defer os.Remove(outputFile.Name())
+
+	outputFile.Close()
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryFile.Name())
+	t.Setenv("GITHUB_OUTPUT", outputFile.Name())
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{
+				Ref:    "refs/heads/main",
+				Object: RefObject{Sha: "base-sha"},
+			})
+		},
+		"POST /repos/owner/repo/git/blobs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha"})
+		},
+		"POST /repos/owner/repo/git/trees": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+		},
+		"POST /repos/owner/repo/git/commits": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+		},
+		"PATCH /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{
+				Ref:    "refs/heads/main",
+				Object: RefObject{Sha: "commit-sha"},
+			})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	sha, err := CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{
+			Branch:  "main",
+			Message: "test commit",
+			Options: CommitOptions{AddNewFiles: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sha != "commit-sha" {
+		t.Errorf("expected commit-sha, got %s", sha)
+	}
+}
+
+func TestCommitAndPush_WithCoauthors(t *testing.T) {
+	resetGlobals()
+
+	tmpFile, err := os.CreateTemp("", "file1.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("package main")
+	tmpFile.Close()
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if args[0] == "add" {
+			return []byte(""), nil
+		}
+
+		return []byte(tmpFile.Name() + "\n"), nil
+	})
+
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	var capturedCommitMsg string
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "base-sha"}})
+		},
+		"POST /repos/owner/repo/git/blobs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha"})
+		},
+		"POST /repos/owner/repo/git/trees": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+		},
+		"POST /repos/owner/repo/git/commits": func(w http.ResponseWriter, r *http.Request) {
+			var req GithubCommitRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			capturedCommitMsg = req.Message
+
+			jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+		},
+		"PATCH /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "commit-sha"}})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	coauthors := []GitUser{{Name: "Alice", Email: "alice@test.com"}}
+
+	_, err = CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{
+			Branch:    "main",
+			Message:   "test commit",
+			Coauthors: &coauthors,
+			Options:   CommitOptions{AddNewFiles: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(capturedCommitMsg, "Co-authored-by: Alice <alice@test.com>") {
+		t.Errorf("expected coauthor in commit message, got: %s", capturedCommitMsg)
+	}
+}
+
+func TestCommitAndPush_BranchNotFound_CreatesBranch(t *testing.T) {
+	resetGlobals()
+
+	tmpFile, err := os.CreateTemp("", "file1.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("content")
+	tmpFile.Close()
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if args[0] == "add" {
+			return []byte(""), nil
+		}
+
+		return []byte(tmpFile.Name() + "\n"), nil
+	})
+
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	headBranch := "main"
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "base-sha"}})
+		},
+		"POST /repos/owner/repo/git/blobs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha"})
+		},
+		"POST /repos/owner/repo/git/trees": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+		},
+		"POST /repos/owner/repo/git/commits": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+		},
+		"PATCH /repos/owner/repo/git/refs/heads/new-branch": func(w http.ResponseWriter, _ *http.Request) {
+			// 404 - branch doesn't exist
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		},
+		"POST /repos/owner/repo/git/refs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubRefResponse{
+				Ref:    "refs/heads/new-branch",
+				Object: RefObject{Sha: "commit-sha"},
+			})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	sha, err := CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{
+			Branch:     "new-branch",
+			HeadBranch: &headBranch,
+			Message:    "test commit",
+			Options:    CommitOptions{AddNewFiles: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sha != "commit-sha" {
+		t.Errorf("expected commit-sha, got %s", sha)
+	}
+}
+
+func TestCommitAndPush_GetReferenceError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"error"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	_, err := CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{Branch: "main", Message: "test"},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "error getting head reference") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCommitAndPush_ForceFlag(t *testing.T) {
+	resetGlobals()
+
+	tmpFile, err := os.CreateTemp("", "file1.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("content")
+	tmpFile.Close()
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if args[0] == "add" {
+			return []byte(""), nil
+		}
+
+		return []byte(tmpFile.Name() + "\n"), nil
+	})
+
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	var capturedForce bool
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "base-sha"}})
+		},
+		"POST /repos/owner/repo/git/blobs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha"})
+		},
+		"POST /repos/owner/repo/git/trees": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+		},
+		"POST /repos/owner/repo/git/commits": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+		},
+		"PATCH /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, r *http.Request) {
+			var req GithubRefRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			capturedForce = req.Force
+
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "commit-sha"}})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	_, err = CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{
+			Branch:  "main",
+			Message: "test commit",
+			Options: CommitOptions{AddNewFiles: true, Force: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !capturedForce {
+		t.Error("expected force flag to be true")
+	}
+}
+
+func TestCommitAndPush_HeadBranchDefaultsToBranch(t *testing.T) {
+	resetGlobals()
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	var capturedRefPath string
+
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "/git/refs/heads/") {
+			capturedRefPath = r.URL.Path
+
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "base-sha"}})
+
+			return
+		}
+		// Return errors for subsequent calls to stop the flow early
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"stop"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return nil, fmt.Errorf("stop here")
+	})
+
+	// HeadBranch is nil, should default to Branch="develop"
+	_, _ = CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{Branch: "develop", Message: "test"},
+	)
+
+	if !strings.Contains(capturedRefPath, "heads/develop") {
+		t.Errorf("expected head branch to default to 'develop', path was: %s", capturedRefPath)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateTagAndPush
+// ---------------------------------------------------------------------------
+
+func TestCreateTagAndPush_NewTag(t *testing.T) {
+	resetGlobals()
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"POST /repos/owner/repo/git/tags": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTagResponse{Sha: "tag-sha", Tag: "v1.0.0"})
+		},
+		"GET /repos/owner/repo/git/refs/tags/v1.0.0": func(w http.ResponseWriter, _ *http.Request) {
+			// 404 - tag doesn't exist
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		},
+		"POST /repos/owner/repo/git/refs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubRefResponse{
+				Ref:    "refs/tags/v1.0.0",
+				Object: RefObject{Sha: "tag-sha"},
+			})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	err := CreateTagAndPush(GitTag{TagName: "v1.0.0", Message: "release", CommitSha: "commit-sha"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTagAndPush_ExistingTag(t *testing.T) {
+	resetGlobals()
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"POST /repos/owner/repo/git/tags": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTagResponse{Sha: "tag-sha", Tag: "v1.0.0"})
+		},
+		"GET /repos/owner/repo/git/refs/tags/v1.0.0": func(w http.ResponseWriter, _ *http.Request) {
+			// Tag exists
+			jsonResponse(w, http.StatusOK, GithubRefResponse{
+				Ref:    "refs/tags/v1.0.0",
+				Object: RefObject{Sha: "old-tag-sha"},
+			})
+		},
+		"PATCH /repos/owner/repo/git/refs/tags/v1.0.0": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{
+				Ref:    "refs/tags/v1.0.0",
+				Object: RefObject{Sha: "tag-sha"},
+			})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	err := CreateTagAndPush(GitTag{TagName: "v1.0.0", Message: "release", CommitSha: "commit-sha"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTagAndPush_CreateTagAPIError(t *testing.T) {
+	resetGlobals()
+	setupTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"error"}`))
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	err := CreateTagAndPush(GitTag{TagName: "v1.0.0", Message: "release", CommitSha: "commit-sha"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateTagAndPush_Non404GetReferenceError(t *testing.T) {
+	resetGlobals()
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"POST /repos/owner/repo/git/tags": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTagResponse{Sha: "tag-sha", Tag: "v1.0.0"})
+		},
+		"GET /repos/owner/repo/git/refs/tags/v1.0.0": func(w http.ResponseWriter, _ *http.Request) {
+			// Non-404 error
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	err := CreateTagAndPush(GitTag{TagName: "v1.0.0", Message: "release", CommitSha: "commit-sha"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "error checking tag reference") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCommitAndPush_AddNewFilesFalse(t *testing.T) {
+	resetGlobals()
+
+	tmpFile, err := os.CreateTemp("", "file1.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, _ = tmpFile.WriteString("content")
+	tmpFile.Close()
+
+	var stageCmdArgs []string
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if args[0] == "add" {
+			stageCmdArgs = args
+
+			return []byte(""), nil
+		}
+
+		return []byte(tmpFile.Name() + "\n"), nil
+	})
+
+	t.Setenv("GITHUB_ACTIONS", "false")
+
+	setupTestServer(t, apiRouter(map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "base-sha"}})
+		},
+		"POST /repos/owner/repo/git/blobs": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubBlobResponse{Sha: "blob-sha"})
+		},
+		"POST /repos/owner/repo/git/trees": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubTreeResponse{Sha: "tree-sha"})
+		},
+		"POST /repos/owner/repo/git/commits": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusCreated, GithubCommitResponse{Sha: "commit-sha"})
+		},
+		"PATCH /repos/owner/repo/git/refs/heads/main": func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, GithubRefResponse{Object: RefObject{Sha: "commit-sha"}})
+		},
+	}))
+	setTestAppToken(t, &GitHubAppToken{
+		Token: "test-token",
+		Repo:  GitHubRepo{Owner: "owner", Repo: "repo"},
+	})
+
+	_, err = CommitAndPush(
+		GitHubRepo{Owner: "owner", Repo: "repo"},
+		GitCommit{
+			Branch:  "main",
+			Message: "test commit",
+			Options: CommitOptions{AddNewFiles: false},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// When AddNewFiles=false, should use StageModifiedFiles which calls "git add -u"
+	if len(stageCmdArgs) >= 2 && stageCmdArgs[1] != "-u" {
+		t.Errorf("expected 'git add -u' for AddNewFiles=false, got args: %v", stageCmdArgs)
+	}
+}

--- a/helper/test_helpers_test.go
+++ b/helper/test_helpers_test.go
@@ -1,0 +1,112 @@
+//nolint:goconst
+package github_helper
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// resetGlobals resets all package-level state so tests are isolated.
+func resetGlobals() {
+	initJwt = sync.Once{}
+	initToken = sync.Once{}
+	ghAppSignedToken = ""
+	ghAppToken = nil
+	initJwtErr = nil
+	githubBaseURL = "https://api.github.com"
+}
+
+// setupTestServer creates an httptest.Server, points githubBaseURL at it, and
+// registers cleanup to restore the original URL.
+func setupTestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(handler)
+	githubBaseURL = ts.URL
+
+	t.Cleanup(func() {
+		ts.Close()
+
+		githubBaseURL = "https://api.github.com"
+	})
+
+	return ts
+}
+
+// generateTestRSAKey generates a 2048-bit RSA private key PEM for testing.
+func generateTestRSAKey(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return pemBytes
+}
+
+// apiRouter maps "METHOD /path" strings to handlers.
+func apiRouter(routes map[string]http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key := fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+
+		// try without trailing slash
+		path := strings.TrimRight(r.URL.Path, "/")
+
+		key = fmt.Sprintf("%s %s", r.Method, path)
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+
+		http.NotFound(w, r)
+	}
+}
+
+// mockExecCommand swaps execCommandFunc for the duration of the test.
+func mockExecCommand(t *testing.T, fn func(command string, args []string) ([]byte, error)) {
+	t.Helper()
+
+	original := execCommandFunc
+	execCommandFunc = fn
+
+	t.Cleanup(func() {
+		execCommandFunc = original
+	})
+}
+
+// jsonResponse writes a JSON response with the given status code.
+func jsonResponse(w http.ResponseWriter, statusCode int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+// setTestAppToken sets ghAppToken for tests that need it.
+func setTestAppToken(t *testing.T, token *GitHubAppToken) {
+	t.Helper()
+
+	ghAppToken = token
+
+	t.Cleanup(func() {
+		ghAppToken = nil
+	})
+}

--- a/helper/utils_test.go
+++ b/helper/utils_test.go
@@ -1,0 +1,402 @@
+//nolint:goconst
+package github_helper
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// executeCommandDefault
+// ---------------------------------------------------------------------------
+
+func TestExecuteCommandDefault_Success(t *testing.T) {
+	output, err := executeCommandDefault("echo", []string{"hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.TrimSpace(string(output)) != "hello" {
+		t.Errorf("expected 'hello', got '%s'", strings.TrimSpace(string(output)))
+	}
+}
+
+func TestExecuteCommandDefault_NonExistent(t *testing.T) {
+	_, err := executeCommandDefault("nonexistent-command-xyz", []string{})
+	if err == nil {
+		t.Fatal("expected error for non-existent command")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StageModifiedAndNewFiles
+// ---------------------------------------------------------------------------
+
+func TestStageModifiedAndNewFiles_Success(t *testing.T) {
+	var calledCmd string
+	var calledArgs []string
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		calledCmd = command
+		calledArgs = args
+
+		return []byte(""), nil
+	})
+
+	err := StageModifiedAndNewFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if calledCmd != "git" {
+		t.Errorf("expected git, got %s", calledCmd)
+	}
+
+	if len(calledArgs) < 2 || calledArgs[0] != "add" || calledArgs[1] != "-A" {
+		t.Errorf("expected 'add -A', got %v", calledArgs)
+	}
+}
+
+func TestStageModifiedAndNewFiles_Error(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return nil, fmt.Errorf("git error")
+	})
+
+	err := StageModifiedAndNewFiles()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StageModifiedFiles
+// ---------------------------------------------------------------------------
+
+func TestStageModifiedFiles_Success(t *testing.T) {
+	var calledArgs []string
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		calledArgs = args
+		return []byte(""), nil
+	})
+
+	err := StageModifiedFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(calledArgs) < 2 || calledArgs[0] != "add" || calledArgs[1] != "-u" {
+		t.Errorf("expected 'add -u', got %v", calledArgs)
+	}
+}
+
+func TestStageModifiedFiles_Error(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return nil, fmt.Errorf("git error")
+	})
+
+	err := StageModifiedFiles()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetModifiedAndNewFiles
+// ---------------------------------------------------------------------------
+
+func TestGetModifiedAndNewFiles_Success(t *testing.T) {
+	callCount := 0
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		callCount++
+		if callCount == 1 {
+			// StageModifiedAndNewFiles → git add -A
+			return []byte(""), nil
+		}
+		// GetModifiedFilesFromGitDiff → git diff --name-only --cached
+		return []byte("file1.go\nfile2.go\n"), nil
+	})
+
+	files, err := GetModifiedAndNewFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestGetModifiedAndNewFiles_StageError(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return nil, fmt.Errorf("stage error")
+	})
+
+	_, err := GetModifiedAndNewFiles()
+	if err == nil {
+		t.Fatal("expected error to propagate from staging")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetModifiedFiles
+// ---------------------------------------------------------------------------
+
+func TestGetModifiedFiles_Success(t *testing.T) {
+	callCount := 0
+
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		callCount++
+		if callCount == 1 {
+			return []byte(""), nil
+		}
+
+		return []byte("modified.go\n"), nil
+	})
+
+	files, err := GetModifiedFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 1 || files[0] != "modified.go" {
+		t.Errorf("unexpected files: %v", files)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetModifiedFilesFromGitDiff
+// ---------------------------------------------------------------------------
+
+func TestGetModifiedFilesFromGitDiff_Staged(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		if command != "git" {
+			t.Errorf("expected git, got %s", command)
+		}
+		// Should have --cached for staged
+		found := false
+
+		for _, a := range args {
+			if a == "--cached" {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Error("expected --cached flag for staged diff")
+		}
+
+		return []byte("a.go\nb.go\n"), nil
+	})
+
+	files, err := GetModifiedFilesFromGitDiff(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestGetModifiedFilesFromGitDiff_Unstaged(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		for _, a := range args {
+			if a == "--cached" {
+				t.Error("did not expect --cached flag for unstaged diff")
+			}
+		}
+
+		return []byte("c.go\n"), nil
+	})
+
+	files, err := GetModifiedFilesFromGitDiff(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestGetModifiedFilesFromGitDiff_EmptyOutput(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return []byte(""), nil
+	})
+
+	files, err := GetModifiedFilesFromGitDiff(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(files))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsGitHubActions
+// ---------------------------------------------------------------------------
+
+func TestIsGitHubActions_True(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	if !IsGitHubActions() {
+		t.Error("expected true when GITHUB_ACTIONS=true")
+	}
+}
+
+func TestIsGitHubActions_Unset(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	if IsGitHubActions() {
+		t.Error("expected false when GITHUB_ACTIONS is not set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendToGHActionsSummary
+// ---------------------------------------------------------------------------
+
+func TestAppendToGHActionsSummary_InActions(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "gh-summary-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Close()
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_STEP_SUMMARY", tmpFile.Name())
+
+	AppendToGHActionsSummary("test summary")
+
+	content, err := os.ReadFile(tmpFile.Name()) //nolint:gosec // test file
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "test summary") {
+		t.Errorf("expected summary content, got: %s", string(content))
+	}
+}
+
+func TestAppendToGHActionsSummary_NotInActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "false")
+	// Should not panic or error
+	AppendToGHActionsSummary("test summary")
+}
+
+// ---------------------------------------------------------------------------
+// SendToGHActionsOutput
+// ---------------------------------------------------------------------------
+
+func TestSendToGHActionsOutput_InActions(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "gh-output-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Close()
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", tmpFile.Name())
+
+	SendToGHActionsOutput("sha", "abc123")
+
+	content, err := os.ReadFile(tmpFile.Name()) //nolint:gosec // test file
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "sha=abc123") {
+		t.Errorf("expected 'sha=abc123', got: %s", string(content))
+	}
+}
+
+func TestSendToGHActionsOutput_NotInActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "false")
+	// Should not panic or error
+	SendToGHActionsOutput("sha", "abc123")
+}
+
+// ---------------------------------------------------------------------------
+// writeToGHActionsVar
+// ---------------------------------------------------------------------------
+
+func TestWriteToGHActionsVar_EmptyName(t *testing.T) {
+	// Should be no-op, no panic
+	writeToGHActionsVar("", "some value")
+}
+
+func TestWriteToGHActionsVar_ValidFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "gh-var-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Close()
+
+	writeToGHActionsVar(tmpFile.Name(), "hello world")
+
+	content, err := os.ReadFile(tmpFile.Name()) //nolint:gosec // test file
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "hello world") {
+		t.Errorf("expected content, got: %s", string(content))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListFiles
+// ---------------------------------------------------------------------------
+
+func TestListFiles_Success(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return []byte("total 8\ndrwxr-xr-x  5 user group 160 Jan  1 12:00 .\ndrwxr-xr-x  3 user group  96 Jan  1 12:00 ..\n-rw-r--r--  1 user group  42 Jan  1 12:00 file.txt\n"), nil
+	})
+
+	files, err := ListFiles(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should have 3 entries (., .., file.txt)
+	if len(files) != 3 {
+		t.Errorf("expected 3 files, got %d", len(files))
+	}
+}
+
+func TestListFiles_Error(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return nil, fmt.Errorf("ls error")
+	})
+
+	_, err := ListFiles(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestListFiles_EmptyOutput(t *testing.T) {
+	mockExecCommand(t, func(command string, args []string) ([]byte, error) {
+		return []byte("total 0\n"), nil
+	})
+
+	files, err := ListFiles(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(files))
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"strings"
+	"testing"
+)
+
+func generateTestRSAKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return pemBytes
+}
+
+func TestRun_HelpFlag(t *testing.T) {
+	err := run([]string{"-help"}, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_VersionFlag(t *testing.T) {
+	err := run([]string{"-version"}, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_MissingRepository(t *testing.T) {
+	err := run([]string{}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for missing repository")
+	}
+	if !strings.Contains(err.Error(), "repository flag is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_InvalidRepoFormat(t *testing.T) {
+	err := run([]string{"-r", "invalid"}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for invalid repo format")
+	}
+	if !strings.Contains(err.Error(), "invalid repository format") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_ValidRepoFormat_MissingAppId(t *testing.T) {
+	err := run([]string{"-r", "owner/repo"}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for missing app id")
+	}
+	if !strings.Contains(err.Error(), "GitHub app id is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_NoPrivateKey(t *testing.T) {
+	err := run([]string{"-r", "owner/repo", "-i", "12345"}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for no private key")
+	}
+	if !strings.Contains(err.Error(), "provide a private key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PEMFromEnvVar(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+	// This will fail at GenerateInstallationAppToken since there's no server,
+	// but it validates PEM parsing succeeds
+	err := run([]string{"-r", "owner/repo", "-i", "12345"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	// Should fail later (at API call), not at PEM parsing
+	if err == nil {
+		t.Fatal("expected error (API call should fail)")
+	}
+	if strings.Contains(err.Error(), "failed to decode PEM") {
+		t.Errorf("PEM parsing should have succeeded, got: %v", err)
+	}
+}
+
+func TestRun_Base64EncodedPEM(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+	encoded := base64.StdEncoding.EncodeToString(pemBytes)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return encoded
+		}
+		return ""
+	})
+	// Should fail later (at API call), not at PEM/base64 parsing
+	if err == nil {
+		t.Fatal("expected error (API call should fail)")
+	}
+	if strings.Contains(err.Error(), "failed to decode PEM") {
+		t.Errorf("base64 PEM parsing should have succeeded, got: %v", err)
+	}
+}
+
+func TestRun_InvalidPEM(t *testing.T) {
+	err := run([]string{"-r", "owner/repo", "-i", "12345"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return "not-a-valid-pem"
+		}
+		return ""
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+	if !strings.Contains(err.Error(), "failed to decode PEM") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_CoauthorParsing_Valid(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-c", "Alice <alice@test.com>"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	// Should fail at API call, not at coauthor parsing
+	if err != nil && strings.Contains(err.Error(), "invalid coauthor format") {
+		t.Errorf("coauthor parsing should have succeeded, got: %v", err)
+	}
+}
+
+func TestRun_CoauthorParsing_Invalid(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-c", "invalid-format"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid coauthor")
+	}
+	if !strings.Contains(err.Error(), "invalid coauthor format") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_DefaultCommitMessage(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	// Just verify it doesn't fail at message parsing
+	if err != nil && strings.Contains(err.Error(), "commit message") {
+		t.Errorf("unexpected commit message error: %v", err)
+	}
+}
+
+func TestRun_PEMFromFile_EmptyFilename(t *testing.T) {
+	// -p flag with empty value + no env var -> should hit "provide a private key" error
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-p", ""}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "provide a private key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PEMFromFile_MissingFile(t *testing.T) {
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-p", "/nonexistent/key.pem"}, func(string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for missing PEM file")
+	}
+	if !strings.Contains(err.Error(), "failed to sign JWT token from file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PEMFromFile_ValidFile(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+	tmpFile, err := createTempPEMFile(t, pemBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = run([]string{"-r", "owner/repo", "-i", "12345", "-p", tmpFile}, func(string) string { return "" })
+	// Should fail at API call, not at PEM file reading
+	if err != nil && strings.Contains(err.Error(), "failed to sign JWT token from file") {
+		t.Errorf("PEM file should have been read successfully, got: %v", err)
+	}
+}
+
+func TestRun_HeadBranchFlag(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-h", "develop", "-b", "main"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	// Should fail at API level, not at flag parsing
+	if err != nil && strings.Contains(err.Error(), "head branch") {
+		t.Errorf("unexpected head branch error: %v", err)
+	}
+}
+
+func TestRun_CustomCommitMessage(t *testing.T) {
+	pemBytes := generateTestRSAKey(t)
+
+	err := run([]string{"-r", "owner/repo", "-i", "12345", "-m", "custom message"}, func(key string) string {
+		if key == "GH_APP_PRIVATE_KEY" {
+			return string(pemBytes)
+		}
+		return ""
+	})
+	// Should fail at API level, not at message parsing
+	if err != nil && strings.Contains(err.Error(), "commit message") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func createTempPEMFile(t *testing.T, pemBytes []byte) (string, error) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "test-pem-*")
+	if err != nil {
+		return "", err
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+	tmpFile.Write(pemBytes)
+	tmpFile.Close()
+	return tmpFile.Name(), nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestBuildVersion_NonEmpty(t *testing.T) {
+	if BuildVersion == "" {
+		t.Error("expected BuildVersion to be non-empty")
+	}
+}


### PR DESCRIPTION
This pull request refactors error handling throughout the GitHub helper and main application code to improve robustness and reliability. Instead of using `panic`, errors are now properly returned and handled, providing clearer error messages and preventing abrupt program termination. Additionally, the handling of private key input is improved to support both plain PEM and base64-encoded PEM formats.

**Error handling improvements:**

* Replaced all `panic` calls in `helper/github.go` and `helper/main.go` with proper error returns, ensuring that errors are reported and can be handled gracefully by the caller. This affects functions like `initAppToken`, `SetGithubAppToken`, `GetReference`, `CreateTree`, `CreateCommit`, `CreateReference`, `UpdateReference`, and `CreateBlob`. [[1]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765R21-R46) [[2]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L84-R91) [[3]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L102-R109) [[4]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L120-R127) [[5]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L138-R145) [[6]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L156-R163) [[7]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L190-R197) [[8]](diffhunk://#diff-cd5f82382f4dd307aabe5722b60151577e012f5a8c7f1174c6bb3e6c70523765L208-R215) [[9]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL114-R159) [[10]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR169-R177) [[11]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR190-R205) [[12]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR231-R234) [[13]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR255-R269) [[14]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL267-R315)

* Updated the main application (`main.go`) to use `log.Fatal` for user-facing error messages instead of `panic`, improving clarity and user experience. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L62-R63) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L71-R72) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L80-R113) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L131-R159) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R173-R175) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L160-R191)

**API and signature changes:**

* Changed several helper function signatures to return errors instead of panicking, including `SignJWTAppToken`, `SignJWTAppTokenWithFilename`, `GenerateInstallationAppToken`, `CommitAndPush`, and `CreateTagAndPush`. Callers are updated to check and handle these errors. [[1]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL114-R159) [[2]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR169-R177) [[3]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR231-R234) [[4]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR255-R269) [[5]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL267-R315) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L131-R159) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R173-R175) [[8]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L160-R191)

**Private key handling improvements:**

* Enhanced private key parsing in `main.go` to support both plain PEM and base64-encoded PEM formats from the environment variable, increasing flexibility for different deployment environments.

**General code quality improvements:**

* Improved error messages throughout the codebase to provide more context and detail for troubleshooting. [[1]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL114-R159) [[2]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR169-R177) [[3]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR190-R205) [[4]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR231-R234) [[5]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbR255-R269) [[6]](diffhunk://#diff-b8ef76911bb89ce167f6d1dd3b1951477e18e95d72eb99a50c896bd632289bfbL267-R315) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L131-R159) [[8]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R173-R175) [[9]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L160-R191)

**Dependency updates:**

* Added the `encoding/base64` import in `main.go` to support base64 decoding of PEM private keys.